### PR TITLE
Add visitor IP to bulk POST data by setting cip and token_auth in eac…

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -242,6 +242,7 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
     global $DEBUG_PROXY;
     global $NO_VERIFY_SSL;
     global $http_ip_forward_header;
+    global $TOKEN_AUTH;
 
     $useFopen = @ini_get('allow_url_fopen') == '1';
 
@@ -283,7 +284,27 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
     // if there's POST data, send our proxy request as a POST
     if (!empty($_POST)) {
         $postBody = file_get_contents("php://input");
+        
+        // Add visitor IP to bulk POST data by setting cip and token_auth in each individual request, just in a single request
+        $data = json_decode($postBody, true);
+        if (isset($data['requests']) && is_array($data['requests'])) {
+            $visitIp = getVisitIp();
 
+            // Add cip and token_auth to each request in the bulk request array
+            foreach ($data['requests'] as &$request) {
+                // Remove leading question mark if present
+                $request = ltrim($request, '?');
+
+                // Add both parameters while preserving the original request string
+                $request = '?' . $request
+                        . '&cip=' . rawurlencode($visitIp)
+                        . '&token_auth=' . rawurlencode($TOKEN_AUTH);
+            }
+
+            // Re-encode as JSON while preserving the original encoding
+            $postBody = json_encode($data, JSON_UNESCAPED_SLASHES);
+        }
+        
         $stream_options['http']['method'] = 'POST';
         $stream_options['http']['header'][] = "Content-type: application/x-www-form-urlencoded";
         $stream_options['http']['header'][] = "Content-Length: " . strlen($postBody);


### PR DESCRIPTION
### Description:

Matomo content tracking did not work if you were using a reverse proxy. This fixes https://github.com/matomo-org/tracker-proxy/issues/94

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] ~~[Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)~~ no UX change
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] ~~[Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)~~ no wording changed
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
