### PR TITLE
Fixes entry condition in matomo proxy

### DIFF
--- a/matomo-proxy.php
+++ b/matomo-proxy.php
@@ -27,10 +27,15 @@ if (empty($filerequest)) {
     $filerequest = isset($_POST['file']) ? $_POST['file'] : null;
 }
 
-if (
-    !(isset($filerequest) && in_array($filerequest, $VALID_FILES))
-    && !(isset($module) && isset($action) && in_array("$module.$action", $SUPPORTED_METHODS))
-) {
+$hasFileRequest = !empty($filerequest);
+$hasSupportedMethod = !empty($module) && !empty($action) && in_array("$module.$action", $SUPPORTED_METHODS, true);
+
+if ($hasFileRequest) {
+    if (!in_array($filerequest, $VALID_FILES, true)) {
+        http_response_code(404);
+        exit;
+    }
+} elseif (!$hasSupportedMethod) {
     http_response_code(404);
     exit;
 }

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -296,6 +296,31 @@ RESPONSE;
         $this->assertEquals(404, $response->getStatusCode());
     }
 
+    public function test_indexphp_requests_with_invalid_file_are_not_proxied_even_if_method_is_allowed()
+    {
+        $response = $this->send(
+            'module=CoreAdminHome&action=optOut&file=plugins/CoreAdminHome/javascripts/notAllowed.js',
+            null,
+            null,
+            null,
+            '/matomo-proxy.php'
+        );
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function test_indexphp_post_requests_with_invalid_file_are_not_proxied_even_if_method_is_allowed()
+    {
+        $response = $this->send(
+            'module=CoreAdminHome&action=optOut&file=plugins/CoreAdminHome/javascripts/notAllowed.js',
+            null,
+            null,
+            null,
+            '/matomo-proxy.php',
+            'POST'
+        );
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
     public function test_indexphp_empty_requests_are_not_proxied()
     {
         $response = $this->send('', null, null, null, '/matomo-proxy.php');


### PR DESCRIPTION
### Description

This fixes a whitelist bypass in matomo-proxy.php.

Previously, a request to the opt-out proxy was accepted if either the file parameter matched $VALID_FILES or module.action matched $SUPPORTED_METHODS. Because proxy.php prioritizes file for JS requests, an attacker could send a valid opt-out module.action together with an arbitrary file value and bypass the file whitelist.

The fix makes file take precedence: when a file parameter is present, it must be explicitly whitelisted. If no file is provided, the request must match one of the supported opt-out module.action pairs. Regression tests were added for both GET and POST variants of the mixed-parameter bypass.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
