### PR TITLE
Adds code to restrict token_auth post param

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -124,6 +124,9 @@ if (strpos($path, 'piwik.php') === 0 || strpos($path, 'matomo.php') === 0) {
             if (isset($_GET[$queryParamToUnset])) {
                 unset($_GET[$queryParamToUnset]);
             }
+            if (isset($_POST[$queryParamToUnset])) {
+                unset($_POST[$queryParamToUnset]);
+            }
         }
     }
 }

--- a/proxy.php
+++ b/proxy.php
@@ -118,16 +118,8 @@ if (strpos($path, 'piwik.php') === 0 || strpos($path, 'matomo.php') === 0) {
         'token_auth' => $TOKEN_AUTH,
     );
 
-    if (!isset($_GET['token_auth'])) {
-        $queryParamsToUnset = ['cdt', 'country', 'region', 'city', 'lat', 'long', 'cip'];
-        foreach ($queryParamsToUnset as $queryParamToUnset) {
-            if (isset($_GET[$queryParamToUnset])) {
-                unset($_GET[$queryParamToUnset]);
-            }
-            if (isset($_POST[$queryParamToUnset])) {
-                unset($_POST[$queryParamToUnset]);
-            }
-        }
+    if (!isset($_GET['token_auth']) && !isset($_POST['token_auth'])) {
+        sanitizeTrackingOverrideParams($_GET);
     }
 }
 
@@ -295,6 +287,10 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
     // if there's POST data, send our proxy request as a POST
     if (!empty($_POST)) {
         $postBody = file_get_contents("php://input");
+        if (!isset($_GET['token_auth']) && !isset($_POST['token_auth'])) {
+            sanitizeTrackingOverrideParams($_POST);
+            $postBody = http_build_query($_POST);
+        }
 
         $stream_options['http']['method'] = 'POST';
         $stream_options['http']['header'][] = "Content-type: application/x-www-form-urlencoded";
@@ -378,4 +374,14 @@ function arrayValue($array, $key, $value = null)
         $value = $array[$key];
     }
     return $value;
+}
+
+function sanitizeTrackingOverrideParams(&$params)
+{
+    $queryParamsToUnset = ['cdt', 'country', 'region', 'city', 'lat', 'long', 'cip'];
+    foreach ($queryParamsToUnset as $queryParamToUnset) {
+        if (isset($params[$queryParamToUnset])) {
+            unset($params[$queryParamToUnset]);
+        }
+    }
 }

--- a/proxy.php
+++ b/proxy.php
@@ -288,8 +288,10 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
     if (!empty($_POST)) {
         $postBody = file_get_contents("php://input");
         if (!isset($_GET['token_auth']) && !isset($_POST['token_auth'])) {
-            sanitizeTrackingOverrideParams($_POST);
-            $postBody = http_build_query($_POST);
+            $didSanitizePostParams = sanitizeTrackingOverrideParams($_POST);
+            if ($didSanitizePostParams) {
+                $postBody = http_build_query($_POST);
+            }
         }
 
         $stream_options['http']['method'] = 'POST';
@@ -378,10 +380,14 @@ function arrayValue($array, $key, $value = null)
 
 function sanitizeTrackingOverrideParams(&$params)
 {
+    $didSanitizeParams = false;
     $queryParamsToUnset = ['cdt', 'country', 'region', 'city', 'lat', 'long', 'cip'];
     foreach ($queryParamsToUnset as $queryParamToUnset) {
         if (isset($params[$queryParamToUnset])) {
             unset($params[$queryParamToUnset]);
+            $didSanitizeParams = true;
         }
     }
+
+    return $didSanitizeParams;
 }

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -213,6 +213,71 @@ RESPONSE;
         $this->assertEquals($expected, $responseBody);
     }
 
+    public function test_post_requests_strip_admin_tracking_params_without_client_token_auth()
+    {
+        $response = $this->send(
+            'foo=bar',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            'country=ru&region=77&city=Moscow&lat=55.75&long=37.61&cdt=2020-01-01+00%3A00%3A00&action_name=spoof'
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'token_auth' => '<token>',
+  'foo' => 'bar',
+)
+array (
+  'action_name' => 'spoof',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_post_requests_keep_admin_tracking_params_with_client_token_auth_in_post_body()
+    {
+        $response = $this->send(
+            'foo=bar',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            'token_auth=client-token&country=ru&region=77&city=Moscow&lat=55.75&long=37.61&cdt=2020-01-01+00%3A00%3A00&action_name=spoof'
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'token_auth' => '<token>',
+  'foo' => 'bar',
+)
+array (
+  'token_auth' => 'client-token',
+  'country' => 'ru',
+  'region' => '77',
+  'city' => 'Moscow',
+  'lat' => '55.75',
+  'long' => '37.61',
+  'cdt' => '2020-01-01 00:00:00',
+  'action_name' => 'spoof',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
     public function test_debug_requests_are_scrubbed_properly()
     {
         $response = $this->send('debug=1');

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -278,6 +278,37 @@ RESPONSE;
         $this->assertEquals($expected, $responseBody);
     }
 
+    public function test_post_requests_preserve_raw_body_when_no_admin_tracking_params_are_removed()
+    {
+        $response = $this->send(
+            'foo=bar&raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            'action_name=hello%20world'
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'token_auth' => '<token>',
+  'foo' => 'bar',
+  'raw_input' => '1',
+)
+array (
+  'action_name' => 'hello world',
+)
+RAW: action_name=hello%20world
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
     public function test_debug_requests_are_scrubbed_properly()
     {
         $response = $this->send('debug=1');


### PR DESCRIPTION
### Description

Adds code to restrict token_auth post param

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
