### PR TITLE
  Harden proxy auth handling and add bulk-request support

### DIFF
--- a/.github/config.php
+++ b/.github/config.php
@@ -7,3 +7,9 @@ $PROXY_URL = 'http://proxy:8080/';
 $TOKEN_AUTH = 'xyz';
 
 $timeout = 5;
+
+// Test-only: lets the suite exercise IP-forward-header handling via the X-Test-Ip-Forward-Header
+// request header. Gated on the local test-server URL so a stray copy to production is inert.
+if (strpos($MATOMO_URL, '/tests/server/') !== false && !empty($_SERVER['HTTP_X_TEST_IP_FORWARD_HEADER'])) {
+    $http_ip_forward_header = $_SERVER['HTTP_X_TEST_IP_FORWARD_HEADER'];
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run this properly you will need:
 
 - latest version of Matomo installed on a server (or Matomo Cloud)
 - one or several website(s) to track with this Matomo, for example `http://{site_to_be_tracked}`
-- the website to track must run on a server with PHP 5.3 or higher
+- the website to track must run on a server with PHP 7.2 or higher
 - PHP must have either the CURL extension enabled or `allow_url_fopen=On`
 
 ## Installation
@@ -114,6 +114,30 @@ You may change this timeout by editing the `$timeout` value in `config.php`.
 By default, the `matomo.php` proxy will contact your Matomo server with the User-Agent of the client requesting `matomo.php`.
 You may force the proxy script to use a particular User-Agent by  editing the `$user_agent` value in `config.php`.
 
+### Visitor IP forwarding
+
+Because the proxy sits between your visitors and Matomo, it has to tell Matomo the real visitor IP — otherwise Matomo would record the proxy's IP. There are two ways this works:
+
+- **Default — via `cip` + `token_auth`:** the proxy sends the visitor IP to Matomo as the `cip` tracking parameter, authorized by the `$TOKEN_AUTH` you configured (this is why the proxy user needs **write** or **admin** permission). Works out of the box with no Matomo-side configuration, for both single requests and bulk requests (the Matomo JavaScript tracker batches several actions into a single bulk request by default).
+- **Header-only — via `$http_ip_forward_header`:** set `$http_ip_forward_header` in `config.php` (for example to `X-Forwarded-For`) to forward the visitor IP in that header instead. In this mode the proxy injects **no** `cip`/`token_auth` at all and relies solely on the header for the visitor IP — so it doesn't even need a write/admin token. **This only works if Matomo is configured to trust the header:** both the web server in front of Matomo (Apache [mod_remoteip](https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html), nginx [realip](https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/)) **and** Matomo's trusted-proxy settings (`proxy_client_headers[]` / `proxy_ips[]` in its `config.ini.php`). If it isn't, Matomo records the proxy's IP for every visitor.
+
+> ⚠️ **Breaking change:** previously `$http_ip_forward_header` was sent *in addition* to `cip`+`token_auth`; the proxy now treats it as the *sole* IP mechanism and injects nothing else. If you already set it, make sure Matomo's trusted-proxy configuration above is in place — otherwise leave it empty to keep using `cip`.
+
+### Auth-protected tracking parameters
+
+Some tracking parameters (`cip`, `cdt`, `cdo`, `country`, `region`, `city`, `lat`, `long`) are only honored by Matomo for an authenticated request. The proxy never lends its `$TOKEN_AUTH` to a request — or to an individual entry of a bulk request — that carries one of these override parameters or its own `token_auth`:
+
+- **Carries an override parameter, no token:** forwarded without the proxy's token, so Matomo rejects/skips it exactly as if it had been sent directly without authentication — rather than being silently tracked with the client-supplied override. To set these parameters legitimately, send your own valid `token_auth`.
+- **Carries its own `token_auth`:** the proxy adds no token of its own and lets the client's token govern. It still forwards the visitor IP as `cip`, so that token must have write access to authorize it (otherwise the request/entry is rejected).
+
+> ⚠️ **Behavior change:** if you add any of these parameters via `appendToTrackingUrl` (or otherwise) without your own `token_auth`, those requests are now **rejected** by Matomo. Previously the proxy stripped the parameter and tracked the rest of the hit; it no longer does. Send a valid `token_auth` if you need these parameters.
+
+> Note: if your Matomo server sets `bulk_requests_require_authentication = 1`, it requires a single batch-level `token_auth` for the whole bulk request. The proxy supplies that batch-level token only when **every** entry in the batch is clean; if any entry carries an override parameter or its own `token_auth`, the proxy withholds it (a batch-level token would wrongly authorize that entry) and Matomo then rejects the **entire** bulk request — clean entries included. Under that configuration, send your own batch-level `token_auth` or avoid mixing override entries into proxied bulk requests.
+
+> Note: bulk tracking requests must be sent with an `application/x-www-form-urlencoded` content type (as the Matomo JavaScript tracker does). Bulk request bodies sent as `application/json` are not forwarded by the proxy.
+
+> Note: the proxy rebuilds the forwarded request from the parameters PHP parsed (`$_GET`/`$_POST`, or the decoded JSON for bulk), so it only ever sends Matomo what it inspected. Make sure the proxy host's PHP `post_max_size` is large enough for your biggest (bulk) tracking requests — a body exceeding it is dropped by PHP and not forwarded.
+
 ## Contributing
 
 If you have found a bug, you are welcome to submit a pull request.
@@ -125,8 +149,15 @@ Before running the tests, create a config.php file w/ the following contents in 
 ```
 <?php
 $MATOMO_URL = 'http://localhost/tests/server/';
+$PROXY_URL = 'http://localhost/';
 $TOKEN_AUTH = 'xyz';
 $timeout = 5;
+
+// Test-only: lets the suite exercise IP-forward-header handling via the X-Test-Ip-Forward-Header
+// request header. Gated on the local test-server URL so a stray copy to production is inert.
+if (strpos($MATOMO_URL, '/tests/server/') !== false && !empty($_SERVER['HTTP_X_TEST_IP_FORWARD_HEADER'])) {
+    $http_ip_forward_header = $_SERVER['HTTP_X_TEST_IP_FORWARD_HEADER'];
+}
 ```
 
 The tests need a webserver to be pointed to the root of this repository. The simplest way is to just use Vagrant:
@@ -149,4 +180,4 @@ $ composer install
 * Check in phpinfo() that `allow_url_fopen = On`
 * Run: `vendor/bin/phpunit`
 
-Be advised that the tests require at least PHP 5.4 to run, but the proxy itself can run with PHP 5.3.
+Be advised that the proxy and its tests require PHP 7.2 or higher.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3 || ^10.1",
         "matomo-org/matomo-coding-standards": "dev-master",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^7.0",
         "squizlabs/php_codesniffer": "^3.9"
     },
     "scripts": {

--- a/config.php.example
+++ b/config.php.example
@@ -26,14 +26,24 @@ $timeout = 5;
 // Edit the line below to force the proxy to always use a specific user agent string.
 $user_agent = '';
 
-// In some situations the backend takes the sending IP address into account
-// which by default is the IP address of the server/service proxy.php is executed from.
-// If $http_forward_header is set, the clients IP address is sent over in the
-// header field with the given name. An empty string means do not send the header. 
-// A common header name is 'X-Forwarded-For'.
+// How the real visitor IP is sent to Matomo.
 //
-// In order to work, the http server serving the matomo instance, has to be configured
-// to honor the additional header.
+// By default ($http_ip_forward_header empty) the proxy sends the visitor IP to Matomo as the
+// `cip` tracking parameter, authorized by your $TOKEN_AUTH. This works out of the box for both
+// single and bulk tracking requests and needs no Matomo-side configuration.
+//
+// Alternatively, set $http_ip_forward_header (e.g. to 'X-Forwarded-For') to forward the visitor
+// IP in that header instead. In this mode the proxy injects NO `cip`/token_auth at all and relies
+// solely on the header for the visitor IP (so this mode does not even require a write/admin token).
+//
+// IMPORTANT: this only works if Matomo is configured to trust the header - both the http server in
+// front of Matomo (Apache mod_remoteip / nginx realip) AND Matomo's trusted-proxy settings
+// (proxy_client_headers[] / proxy_ips[] in its config.ini.php). If it is not, Matomo records the
+// proxy's IP for every visitor.
+//
+// BREAKING CHANGE: previously this header was sent in addition to `cip`+token; setting it now
+// switches the proxy to header-only IP forwarding. If you already set it, verify the Matomo
+// trusted-proxy configuration above, or leave it empty to keep using `cip`.
 //
 // For apache http see https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
 // for nginx see https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/

--- a/proxy.php
+++ b/proxy.php
@@ -106,6 +106,10 @@ if ((empty($_GET) && empty($_POST)) || (isset($filerequest) && substr($filereque
 }
 @ini_set('magic_quotes_runtime', 0);
 
+// Read the request body once; php://input may not be re-readable on older PHP versions.
+$rawPostBody = file_get_contents("php://input");
+$forwardPostBody = $rawPostBody;
+
 // 2) MATOMO.PHP PROXY: GET parameters found, this is a tracking request, we redirect it to Piwik
 if (strpos($path, '?') === false) {
     $path = $path . '?';
@@ -113,14 +117,42 @@ if (strpos($path, '?') === false) {
 
 $extraQueryParams = array();
 if (strpos($path, 'piwik.php') === 0 || strpos($path, 'matomo.php') === 0) {
-    $extraQueryParams = array(
-        'cip' => getVisitIp(),
-        'token_auth' => $TOKEN_AUTH,
-    );
+    // Without an IP-forward header, send the visitor IP as `cip` authorized by our token_auth - but
+    // only when the client sent no token_auth or auth-protected param, so we never authorize its override.
+    if (empty($http_ip_forward_header)) {
+        // Same bulk detection as Matomo's Requests::isUsingBulkRequest (both quote variants).
+        $isBulk = $rawPostBody !== ''
+            && (strpos($rawPostBody, '"requests"') !== false || strpos($rawPostBody, "'requests'") !== false);
 
-    if (!isset($_GET['token_auth']) && !isset($_POST['token_auth'])) {
-        sanitizeTrackingOverrideParams($_GET);
+        if ($isBulk) {
+            // Matomo reads the bulk token only from the JSON body, so pass any URL token_auth down to
+            // be relocated there. Only $_GET matters here - for a bulk POST, $_POST is the mangled body.
+            $clientUrlToken = (isset($_GET['token_auth']) && is_string($_GET['token_auth']) && $_GET['token_auth'] !== '')
+                ? $_GET['token_auth']
+                : null;
+            $forwardPostBody = injectVisitIpIntoBulkRequest($rawPostBody, getVisitIp(), $TOKEN_AUTH, $clientUrlToken);
+            // The batch token now lives in the JSON body; never also send one in the forwarded query.
+            unset($_GET['token_auth']);
+        } else {
+            if (!isset($_GET['cip']) && !isset($_POST['cip'])) {
+                $extraQueryParams['cip'] = getVisitIp();
+            }
+            if (!clientProvidesAuthParams($_GET) && !clientProvidesAuthParams($_POST)) {
+                // Drop any empty/array token_auth the client sent so it can't clobber ours when
+                // $_GET is merged below (array_merge lets $_GET win on key collision).
+                unset($_GET['token_auth']);
+                $extraQueryParams['token_auth'] = $TOKEN_AUTH;
+            }
+
+            // Rebuild the body from parsed $_POST, not the raw bytes, so it matches the params our token
+            // decision saw: a param dropped by max_input_vars is absent from both and can't slip past us.
+            if (!empty($_POST)) {
+                $forwardPostBody = http_build_query($_POST);
+            }
+        }
     }
+    // With an IP-forward header set, the visitor IP goes in that header (see getHttpContentAndStatus);
+    // we inject no cip/token and let Matomo apply its own auth rules.
 }
 
 $url = $MATOMO_URL . $path;
@@ -128,7 +160,7 @@ $url .= http_build_query(array_merge($extraQueryParams, $_GET));
 
 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
     // PHP 5.2 breaks with the new 204 status code so we force returning the image every time
-    list($content, $httpStatus) = getHttpContentAndStatus($url . '&send_image=1', $timeout, $user_agent);
+    list($content, $httpStatus) = getHttpContentAndStatus($url . '&send_image=1', $timeout, $user_agent, $forwardPostBody);
     $content = sanitizeContent($content);
 
     forwardHeaders($content);
@@ -136,7 +168,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
     echo $content;
 } else {
     // PHP 5.3 and above
-    list($content, $httpStatus) = getHttpContentAndStatus($url, $timeout, $user_agent);
+    list($content, $httpStatus) = getHttpContentAndStatus($url, $timeout, $user_agent, $forwardPostBody);
     $content = sanitizeContent($content);
 
     forwardHeaders($content);
@@ -159,7 +191,13 @@ function sanitizeContent($content)
     $matomoHost = parse_url($MATOMO_URL, PHP_URL_HOST);
     $proxyHost = parse_url($PROXY_URL, PHP_URL_HOST);
 
-    $content = str_replace($TOKEN_AUTH, '<token>', $content);
+    // Scrub the token in raw and URL-encoded form (we inject it through http_build_query, which
+    // percent-encodes it, so a non-hex token could otherwise be reflected back unscrubbed).
+    $tokenForms = array_unique(array($TOKEN_AUTH, rawurlencode($TOKEN_AUTH), urlencode($TOKEN_AUTH)));
+    foreach ($tokenForms as $tokenForm) {
+        $content = str_replace($tokenForm, '<token>', $content);
+    }
+
     $content = str_replace($MATOMO_URL, $PROXY_URL, $content);
     $content = str_replace($matomoHost, $proxyHost, $content);
 
@@ -240,7 +278,7 @@ function handleHeaderLine($curl, $headerLine)
     return $originalByteCount;
 }
 
-function getHttpContentAndStatus($url, $timeout, $user_agent)
+function getHttpContentAndStatus($url, $timeout, $user_agent, $postBody = '')
 {
     global $httpResponseHeaders;
     global $DEBUG_PROXY;
@@ -284,25 +322,18 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
         );
     }
 
+    // Forward the visitor IP via the configured header, for every request method.
+    if (!empty($http_ip_forward_header)) {
+        $visitIp = getVisitIp();
+        $stream_options['http']['header'][] = "$http_ip_forward_header: $visitIp";
+    }
+
     // if there's POST data, send our proxy request as a POST
     if (!empty($_POST)) {
-        $postBody = file_get_contents("php://input");
-        if (!isset($_GET['token_auth']) && !isset($_POST['token_auth'])) {
-            $didSanitizePostParams = sanitizeTrackingOverrideParams($_POST);
-            if ($didSanitizePostParams) {
-                $postBody = http_build_query($_POST);
-            }
-        }
-
         $stream_options['http']['method'] = 'POST';
         $stream_options['http']['header'][] = "Content-type: application/x-www-form-urlencoded";
         $stream_options['http']['header'][] = "Content-Length: " . strlen($postBody);
         $stream_options['http']['content'] = $postBody;
-
-        if (!empty($http_ip_forward_header)) {
-            $visitIp = getVisitIp();
-            $stream_options['http']['header'][] = "$http_ip_forward_header: $visitIp";
-        }
     }
 
     if ($useFopen) {
@@ -378,16 +409,167 @@ function arrayValue($array, $key, $value = null)
     return $value;
 }
 
-function sanitizeTrackingOverrideParams(&$params)
+function clientProvidesAuthParams($params)
 {
-    $didSanitizeParams = false;
-    $queryParamsToUnset = ['cdt', 'country', 'region', 'city', 'lat', 'long', 'cip'];
-    foreach ($queryParamsToUnset as $queryParamToUnset) {
-        if (isset($params[$queryParamToUnset])) {
-            unset($params[$queryParamToUnset]);
-            $didSanitizeParams = true;
+    if (!is_array($params)) {
+        return false;
+    }
+
+    // A non-empty string token_auth counts as client auth, exactly as Matomo reads it; an empty or
+    // array token is ignored by Matomo, so we must not treat it as one either.
+    if (isset($params['token_auth']) && is_string($params['token_auth']) && $params['token_auth'] !== '') {
+        return true;
+    }
+
+    // Params Matomo only honors for an authenticated request. Checked by key presence
+    // (type-agnostic) so it cannot be evaded with array/empty values.
+    $overrideParams = array('cdt', 'cdo', 'country', 'region', 'city', 'lat', 'long', 'cip');
+
+    foreach ($overrideParams as $param) {
+        if (array_key_exists($param, $params)) {
+            return true;
         }
     }
 
-    return $didSanitizeParams;
+    return false;
+}
+
+function withProxyTracking(
+    $params,
+    $visitIp,
+    #[\SensitiveParameter]
+    $tokenAuth,
+    $includeProxyToken
+) {
+    // The entry is clean (no cip of its own), so set the real visitor IP.
+    $params['cip'] = $visitIp;
+
+    // Lend our token only when the caller decided to; otherwise a client token authorizes the cip.
+    if ($includeProxyToken) {
+        $params['token_auth'] = $tokenAuth;
+    }
+
+    return $params;
+}
+
+function bulkEntryProvidesAuthParams($request)
+{
+    // Parse an entry exactly like rewriteBulkEntry(), so the batch scan and the rewrite agree.
+    if (is_string($request)) {
+        $parsedUrl = @parse_url($request);
+        if (empty($parsedUrl['query'])) {
+            return false; // no query: Matomo ignores this entry
+        }
+
+        $params = array();
+        @parse_str($parsedUrl['query'], $params);
+
+        return clientProvidesAuthParams($params);
+    }
+
+    if (is_array($request)) {
+        return clientProvidesAuthParams($request);
+    }
+
+    return false;
+}
+
+function rewriteBulkEntry(
+    $request,
+    $visitIp,
+    #[\SensitiveParameter]
+    $tokenAuth,
+    $includeProxyToken
+) {
+    // Clean entries get our cip (plus our token when $includeProxyToken); an entry with its own auth
+    // params is left untouched for Matomo to reject. Parsing mirrors Matomo's BulkTracking plugin.
+    if (is_string($request)) {
+        $parsedUrl = @parse_url($request);
+        if (empty($parsedUrl['query'])) {
+            return $request; // no query: Matomo ignores this entry
+        }
+
+        $params = array();
+        @parse_str($parsedUrl['query'], $params);
+
+        if (clientProvidesAuthParams($params)) {
+            return $request;
+        }
+
+        return '?' . http_build_query(withProxyTracking($params, $visitIp, $tokenAuth, $includeProxyToken));
+    }
+
+    if (is_array($request)) {
+        if (clientProvidesAuthParams($request)) {
+            return $request;
+        }
+
+        return withProxyTracking($request, $visitIp, $tokenAuth, $includeProxyToken);
+    }
+
+    return $request;
+}
+
+function injectVisitIpIntoBulkRequest(
+    $rawPostBody,
+    $visitIp,
+    #[\SensitiveParameter]
+    $tokenAuth,
+    #[\SensitiveParameter]
+    $clientUrlToken = null
+) {
+    // Strip line breaks before decoding, as Matomo does (Common::sanitizeLineBreaks).
+    $data = json_decode(str_replace(array("\n", "\r"), '', trim($rawPostBody)), true);
+
+    // Not a decodable bulk request: forward unchanged and let Matomo deal with it.
+    if (!is_array($data) || !isset($data['requests']) || !is_array($data['requests'])) {
+        return $rawPostBody;
+    }
+
+    // Read the body token string-only, exactly as Matomo does.
+    $clientHasBodyToken = isset($data['token_auth']) && is_string($data['token_auth']) && $data['token_auth'] !== '';
+    $clientHasUrlToken = $clientUrlToken !== null;
+
+    // Matomo reads the bulk token only from the body. Relocate a URL token there (when the body has
+    // none) so our injected cip is authorized deterministically, not via Matomo's global $_GET fallback.
+    if ($clientHasUrlToken && !$clientHasBodyToken) {
+        $data['token_auth'] = $clientUrlToken;
+        $clientHasBodyToken = true;
+    }
+
+    $clientAuthenticates = $clientHasUrlToken || $clientHasBodyToken;
+
+    // Does any entry carry an auth-protected override param or its own token_auth?
+    $anyOffendingEntry = false;
+    foreach ($data['requests'] as $request) {
+        if (bulkEntryProvidesAuthParams($request)) {
+            $anyOffendingEntry = true;
+            break;
+        }
+    }
+
+    // A top-level token authorizes EVERY entry, so lend ours there only for a fully clean batch with
+    // no client token - then it authorizes nothing but our injected cip, and it also satisfies Matomo's
+    // bulk auth gate (bulk_requests_require_authentication checks each request's top-level token).
+    $useTopLevelProxyToken = !$clientAuthenticates && !$anyOffendingEntry;
+
+    if ($useTopLevelProxyToken) {
+        $data['token_auth'] = $tokenAuth;
+    }
+
+    // Otherwise (mixed batch, no client token) fall back to per-entry tokens on the clean entries;
+    // with a top-level token or client auth, entries get cip only. Per-entry tokens do NOT satisfy
+    // Matomo's bulk auth gate (it checks each request's top-level token), so on a server with
+    // bulk_requests_require_authentication=1 a mixed batch is rejected in full.
+    $includeProxyTokenPerEntry = !$clientAuthenticates && !$useTopLevelProxyToken;
+
+    foreach ($data['requests'] as $index => $request) {
+        $data['requests'][$index] = rewriteBulkEntry($request, $visitIp, $tokenAuth, $includeProxyTokenPerEntry);
+    }
+
+    $encoded = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+    // Fall back to the original body if re-encoding fails (e.g. invalid UTF-8 from parse_str),
+    // so a malformed entry can never drop the whole batch.
+    return $encoded === false ? $rawPostBody : $encoded;
 }

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -213,7 +213,7 @@ RESPONSE;
         $this->assertEquals($expected, $responseBody);
     }
 
-    public function test_post_requests_strip_admin_tracking_params_without_client_token_auth()
+    public function test_post_requests_without_client_token_get_no_proxy_token_and_params_are_kept()
     {
         $response = $this->send(
             'foo=bar',
@@ -227,13 +227,20 @@ RESPONSE;
 
         $responseBody = $this->getBody($response);
 
+        // The client supplied auth-protected params but no token, so the proxy must NOT lend its
+        // token_auth. The params are forwarded untouched; Matomo rejects the request itself.
         $expected = <<<RESPONSE
 array (
   'cip' => '127.0.0.1',
-  'token_auth' => '<token>',
   'foo' => 'bar',
 )
 array (
+  'country' => 'ru',
+  'region' => '77',
+  'city' => 'Moscow',
+  'lat' => '55.75',
+  'long' => '37.61',
+  'cdt' => '2020-01-01 00:00:00',
   'action_name' => 'spoof',
 )
 RESPONSE;
@@ -242,7 +249,7 @@ RESPONSE;
         $this->assertEquals($expected, $responseBody);
     }
 
-    public function test_post_requests_keep_admin_tracking_params_with_client_token_auth_in_post_body()
+    public function test_post_requests_with_client_token_auth_keep_params_and_get_no_proxy_token()
     {
         $response = $this->send(
             'foo=bar',
@@ -256,10 +263,11 @@ RESPONSE;
 
         $responseBody = $this->getBody($response);
 
+        // The client authenticates itself: the proxy keeps its own token out (so Matomo uses the
+        // client token) and forwards the params unchanged.
         $expected = <<<RESPONSE
 array (
   'cip' => '127.0.0.1',
-  'token_auth' => '<token>',
   'foo' => 'bar',
 )
 array (
@@ -278,7 +286,124 @@ RESPONSE;
         $this->assertEquals($expected, $responseBody);
     }
 
-    public function test_post_requests_preserve_raw_body_when_no_admin_tracking_params_are_removed()
+    public function test_get_request_with_admin_param_without_token_gets_cip_but_no_token()
+    {
+        $response = $this->send('idsite=1&country=ru');
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'idsite' => '1',
+  'country' => 'ru',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_get_request_with_cdo_without_token_gets_cip_but_no_token()
+    {
+        // cdo (custom datetime offset) backdates the visit and requires auth in Matomo, so it must
+        // also withhold our token.
+        $response = $this->send('idsite=1&cdo=200000');
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'idsite' => '1',
+  'cdo' => '200000',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_get_request_with_client_cip_is_not_overridden_and_gets_no_token()
+    {
+        $response = $this->send('idsite=1&cip=6.6.6.6&country=ru');
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'idsite' => '1',
+  'cip' => '6.6.6.6',
+  'country' => 'ru',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_empty_token_auth_alone_is_tracked_with_proxy_token()
+    {
+        // An empty token_auth is "no token" (as Matomo reads it). With no override present the
+        // proxy injects its cip+token (and drops the empty client token so it can't clobber ours).
+        $response = $this->send('idsite=1&token_auth=');
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'token_auth' => '<token>',
+  'idsite' => '1',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_array_token_auth_alone_is_tracked_with_proxy_token()
+    {
+        // Same as above with an array-typed token_auth, which Matomo also ignores.
+        $response = $this->send('idsite=1&token_auth[]=x');
+
+        $responseBody = $this->getBody($response);
+
+        $expected = <<<RESPONSE
+array (
+  'cip' => '127.0.0.1',
+  'token_auth' => '<token>',
+  'idsite' => '1',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_empty_token_auth_with_override_does_not_receive_proxy_token()
+    {
+        // Empty token + an override: the override alone must withhold our token (type-juggling
+        // bypass), so Matomo rejects the cip instead of us authorizing it.
+        $response = $this->send('idsite=1&token_auth=&cip=6.6.6.6');
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('<token>', $responseBody);
+    }
+
+    public function test_array_token_auth_with_override_does_not_receive_proxy_token()
+    {
+        $response = $this->send('idsite=1&token_auth[]=x&country=ru');
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('<token>', $responseBody);
+    }
+
+    public function test_post_requests_forward_body_rebuilt_from_parsed_post()
     {
         $response = $this->send(
             'foo=bar&raw_input=1',
@@ -292,6 +417,8 @@ RESPONSE;
 
         $responseBody = $this->getBody($response);
 
+        // The forwarded body is rebuilt from the parsed $_POST (so it only ever contains what the
+        // proxy inspected); the value is unchanged, only the space re-encodes as '+'.
         $expected = <<<RESPONSE
 array (
   'cip' => '127.0.0.1',
@@ -302,7 +429,325 @@ array (
 array (
   'action_name' => 'hello world',
 )
-RAW: action_name=hello%20world
+RAW: action_name=hello+world
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_bulk_request_injects_cip_and_top_level_token_into_clean_batch()
+    {
+        $body = '{"requests":["?idsite=1&rec=1&action_name=one","?idsite=1&rec=1&action_name=two"],"send_image":0}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // A fully clean batch gets cip injected per entry, and our token once at the JSON body top
+        // level - one token authorizes the whole clean batch and satisfies Matomo's bulk auth gate.
+        $this->assertStringContainsString('action_name=one&cip=', $responseBody);
+        $this->assertStringContainsString('action_name=two&cip=', $responseBody);
+        // The token is set at the top level (sanitized to <token>), not per entry.
+        $this->assertStringContainsString('"token_auth":"<token>"', $responseBody);
+        $this->assertEquals(0, substr_count($responseBody, 'token_auth=<token>'));
+
+        // The outer query carries only what the client sent - no cip/token injected at that level.
+        $expectedGet = <<<GET
+array (
+  'raw_input' => '1',
+)
+GET;
+        $this->assertStringContainsString($expectedGet, $responseBody);
+    }
+
+    public function test_bulk_request_leaves_offending_string_entry_untouched()
+    {
+        $body = '{"requests":["?idsite=1&rec=1&action_name=clean","?idsite=1&rec=1&country=ru"]}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // The clean entry is injected; the offending entry (country, no token) is left verbatim so
+        // Matomo rejects it - it receives no cip/token from us.
+        $this->assertStringContainsString('action_name=clean&cip=', $responseBody);
+        $this->assertStringContainsString('"?idsite=1&rec=1&country=ru"', $responseBody);
+        $this->assertEquals(1, substr_count($responseBody, 'token_auth=<token>'));
+    }
+
+    public function test_bulk_request_with_offending_entry_does_not_set_top_level_token()
+    {
+        // One clean entry + one offending entry (country, no token). A top-level token would
+        // authorize EVERY entry, so the offending entry must keep us from setting one - we fall back
+        // to per-entry injection on the clean entry only.
+        $body = '{"requests":["?idsite=1&rec=1&action_name=clean","?idsite=1&rec=1&country=ru"]}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // The clean entry still gets its own per-entry cip + token (URL form), the offending entry is
+        // left verbatim, and crucially there is no batch-level token (JSON form) authorizing them all.
+        $this->assertStringContainsString('action_name=clean&cip=', $responseBody);
+        $this->assertEquals(1, substr_count($responseBody, 'token_auth=<token>'));
+        $this->assertStringContainsString('"?idsite=1&rec=1&country=ru"', $responseBody);
+        $this->assertStringNotContainsString('"token_auth":"<token>"', $responseBody);
+    }
+
+    public function test_bulk_request_leaves_offending_object_entry_untouched()
+    {
+        $body = '{"requests":[{"idsite":"1","rec":"1","action_name":"clean"},{"idsite":"1","cip":"6.6.6.6"}]}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // Clean object entry gets cip + token injected (cip key appended right after action_name).
+        $this->assertStringContainsString('"action_name":"clean","cip":', $responseBody);
+        $this->assertStringContainsString('"token_auth":"<token>"', $responseBody);
+        // The offending object entry (cip, no token) is left exactly as sent.
+        $this->assertStringContainsString('{"idsite":"1","cip":"6.6.6.6"}', $responseBody);
+    }
+
+    public function test_bulk_request_with_top_level_token_injects_cip_only()
+    {
+        $body = '{"requests":["?idsite=1&rec=1&action_name=one"],"token_auth":"client-token"}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // The client authenticates the batch with its body token: clean entries get cip (which
+        // that token authorizes) but NOT our token; the client's body token is preserved.
+        $this->assertStringContainsString('action_name=one&cip=', $responseBody);
+        $this->assertStringNotContainsString('token_auth=', $responseBody);
+        $this->assertStringContainsString('"token_auth":"client-token"', $responseBody);
+    }
+
+    public function test_bulk_request_with_url_token_is_relocated_into_body()
+    {
+        $body = '{"requests":["?idsite=1&rec=1&action_name=one"],"send_image":0}';
+
+        $response = $this->send(
+            'raw_input=1&token_auth=client-token',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // The client authenticates via the URL token. Matomo reads the bulk token only from the body,
+        // so we relocate the client's token into the body top level (and drop it from the outer query).
+        // Clean entries get cip - which that token authorizes - but never our own token.
+        $this->assertStringContainsString('action_name=one&cip=', $responseBody);
+        $this->assertStringNotContainsString('<token>', $responseBody);
+        $this->assertStringContainsString('"token_auth":"client-token"', $responseBody);
+        // The client token was moved out of the outer query into the body, not left in $_GET.
+        $this->assertStringNotContainsString("'token_auth' => 'client-token'", $responseBody);
+    }
+
+    public function test_forward_header_mode_does_not_inject_cip_or_token_for_single_request()
+    {
+        $response = $this->send(
+            'idsite=1&action_name=clean',
+            null,
+            null,
+            ['X-Test-Ip-Forward-Header' => 'X-Forwarded-For']
+        );
+
+        $responseBody = $this->getBody($response);
+
+        // With an IP-forward header configured the proxy injects nothing; the visitor IP is sent
+        // in the configured header (for GET too), and Matomo derives the IP from the connection.
+        $expected = <<<RESPONSE
+array (
+  'idsite' => '1',
+  'action_name' => 'clean',
+)
+array (
+  'X_FORWARDED_FOR' => '127.0.0.1',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_forward_header_mode_forwards_bulk_body_verbatim()
+    {
+        $body = '{"requests":["?idsite=1&rec=1&country=ru"],"send_image":0}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded', 'X-Test-Ip-Forward-Header' => 'X-Forwarded-For'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // No rewriting in forward-header mode: the body (including the offending entry) is passed
+        // through unchanged and the proxy injects no cip/token.
+        $this->assertStringContainsString('RAW: ' . $body, $responseBody);
+        $this->assertStringNotContainsString('cip=', $responseBody);
+        $this->assertStringNotContainsString('token_auth=', $responseBody);
+    }
+
+    public function test_bulk_request_leaves_offending_object_entry_with_country_untouched()
+    {
+        $body = '{"requests":[{"idsite":"1","action_name":"clean"},{"idsite":"1","country":"ru"}]}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        // Clean object entry gets cip + token; the offending object entry (country) is verbatim.
+        $this->assertStringContainsString('"action_name":"clean","cip":', $responseBody);
+        $this->assertStringContainsString('"token_auth":"<token>"', $responseBody);
+        $this->assertStringContainsString('{"idsite":"1","country":"ru"}', $responseBody);
+    }
+
+    public function test_post_form_with_client_cip_is_not_overridden_and_gets_no_token()
+    {
+        $response = $this->send(
+            'foo=bar',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            'cip=6.6.6.6&action_name=x'
+        );
+
+        $responseBody = $this->getBody($response);
+
+        // Client cip in the POST body: the proxy adds neither its own cip nor a token.
+        $expected = <<<RESPONSE
+array (
+  'foo' => 'bar',
+)
+array (
+  'cip' => '6.6.6.6',
+  'action_name' => 'x',
+)
+RESPONSE;
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expected, $responseBody);
+    }
+
+    public function test_bulk_request_with_invalid_json_is_forwarded_unchanged()
+    {
+        // Contains "requests" (so it's treated as bulk) but is not decodable: forward verbatim.
+        $body = '{"requests":[}';
+
+        $response = $this->send(
+            'raw_input=1',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded'],
+            null,
+            'POST',
+            $body
+        );
+
+        $responseBody = $this->getBody($response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('RAW: ' . $body, $responseBody);
+        $this->assertStringNotContainsString('cip=', $responseBody);
+        $this->assertStringNotContainsString('token_auth=', $responseBody);
+    }
+
+    public function test_forward_header_mode_does_not_inject_for_single_post()
+    {
+        $response = $this->send(
+            'foo=bar',
+            null,
+            null,
+            ['content-type' => 'application/x-www-form-urlencoded', 'X-Test-Ip-Forward-Header' => 'X-Forwarded-For'],
+            null,
+            'POST',
+            'action_name=clean'
+        );
+
+        $responseBody = $this->getBody($response);
+
+        // Forward-header mode: nothing injected, body forwarded, visitor IP only in the header.
+        $expected = <<<RESPONSE
+array (
+  'foo' => 'bar',
+)
+array (
+  'action_name' => 'clean',
+)
+array (
+  'X_FORWARDED_FOR' => '127.0.0.1',
+)
 RESPONSE;
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -328,7 +773,6 @@ TOKEN_AUTH: <token>
 RESPONSE;
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(131, $response->getHeader('content-length')[0]);
         $this->assertEquals($expected, $responseBody);
     }
 

--- a/tests/server/matomo.php
+++ b/tests/server/matomo.php
@@ -16,8 +16,14 @@ if (!empty($_POST)) {
     var_export($_POST);
 }
 
+// Echo the raw request body so tests can assert on the exact forwarded payload (e.g. bulk
+// requests). Enabled per-request via the `raw_input` query parameter to keep other tests stable.
+if (!empty($_GET['raw_input'])) {
+    echo "\nRAW: " . file_get_contents('php://input');
+}
+
 $headers = array();
-foreach (array('DNT', 'X_DO_NOT_TRACK') as $headerName) {
+foreach (array('DNT', 'X_DO_NOT_TRACK', 'X_FORWARDED_FOR') as $headerName) {
     if (isset($_SERVER['HTTP_' . $headerName])) {
         $headers[$headerName] = $_SERVER['HTTP_' . $headerName];
     }


### PR DESCRIPTION
  ## Summary

  Hardens how the tracker-proxy handles authentication-controlled tracking parameters, and adds proper support for **bulk tracking requests**. The proxy no longer lets its privileged `token_auth` authorize parameters a client tried to set itself (IP / location / timestamp overrides), for both single and bulk requests, while still recording the correct visitor IP.

  ## Background

  The proxy forwards browser tracking requests to a hidden Matomo server and injects two things: the real visitor IP as `cip`, and a privileged `token_auth` (write/admin) needed to authorize that `cip`. The side effect is that the same token authorizes **every** auth-controlled parameter in the request. In Matomo, `cip`, `country`, `region`, `city`, `lat`, `long`, `cdt` and `cdo` are only honored for an authenticated request — otherwise the request is **rejected** (`InvalidRequestParameterException` → HTTP 400 for a single request; the offending entry is skipped for a bulk request). So a visitor who appended e.g. `&country=ru&cdt=…` would have those overrides authorized by the proxy's token and silently tracked.

  A previous change (#103) addressed this for single requests by *stripping* the override params. That had two problems:

  1. **Bulk requests were not covered.** Matomo's JS tracker batches multiple actions into a single `{"requests":[…]}` POST by default, and the overrides live inside the nested entries — which the strip logic never inspected. The proxy's token (reached via Matomo's auth fallback) then authorized them.
  2. **Type-juggling bypass.** The "did the client send a token?" check used `isset()`, so `token_auth=` (empty) or `token_auth[]=x` (array) made the proxy skip stripping while Matomo treated the token as absent and fell back to the injected privileged token.

  It also changed semantics in a questionable way: stripping turns a request Matomo would *reject* into one that *tracks* (minus the override).

  ## What changed

  **Approach: withhold the token instead of stripping params.** The proxy injects its `token_auth` only for requests/entries that did **not** try to override anything. Anything carrying its own auth-controlled param (or its own `token_auth`) gets no token from us, so Matomo applies its native rules — rejecting a single request, skipping an offending bulk entry — rather than us
  laundering it.

  - **Bulk requests** (`proxy.php` `injectVisitIpIntoBulkRequest`): the body is parsed exactly the way Matomo's `BulkTracking` plugin parses it (`json_decode`, `parse_url`+`parse_str` for string entries, arrays used directly, same `"requests"` detection, `sanitizeLineBreaks`). Each *clean* entry gets `cip` + `token_auth` injected; offending entries are left verbatim. A client-supplied top-level `token_auth` makes the whole body pass through untouched (the client's token governs).
  - **Two visitor-IP modes:**
    - `$http_ip_forward_header` **set** → the proxy injects nothing; the visitor IP is sent in that header (now for GET as well as POST) and Matomo derives it from the connection. Cleanest, no token involved.
    - **not set** (default) → the IP is conveyed via `cip`, authorized by the token, only on clean requests/entries.
  - **Type-juggling safe:** a client `token_auth` counts only when it's a non-empty string (matching how Matomo reads it); auth-controlled params are detected by key presence, so empty/array values can't slip past. Includes both `cdt` and `cdo`.
  - **Client `cip` is never overridden** — if the client sent one, we don't add ours (an authorized client may set it; an unauthorized one is rejected).

  ## Why this approach

  We deliberately do **not** track a request Matomo would reject. If a client includes an auth-controlled override without valid auth, the proxy refuses to lend its token, so Matomo rejects/skips it — same outcome as sending it directly. Clean requests (the normal case) are unaffected and still get the correct visitor IP.

  ## Verified against Matomo

  - Bulk entries are built only from the JSON body, so a GET `cip` never reaches them — per-entry `cip` injection is genuinely required (`core/Tracker/RequestSet.php`, `plugins/BulkTracking/Tracker/Requests.php`).
  - `cdo` alone backdates the visit (`cdt = now - abs(cdo)`) and requires auth if older than 24h (`core/Tracker/Request.php::getCustomTimestamp`).
  - Token resolution / conflict validation (`core/Request/AuthenticationToken.php`)  — the proxy never creates a conflicting second token source.
  - The auth-gated parameter set matches Matomo's (`RequestHandlerTrait::$fieldsThatRequireAuth` + `Request.php`).


replaces #95

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
